### PR TITLE
js: downloads: Remove toLowerCase() from codename in fetchFlavorData URL

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -171,7 +171,7 @@ function createDeviceElements(devices) {
  */
 async function fetchFlavorData(codename, type) {
   try {
-    const url = `https://raw.githubusercontent.com/AxionAOSP/official_devices/main/OTA/${type}/${codename.toLowerCase()}.json`;
+    const url = `https://raw.githubusercontent.com/AxionAOSP/official_devices/main/OTA/${type}/${codename}.json`;
     console.log(`Fetching ${type} data from: ${url}`);
     
     const res = await fetch(url);


### PR DESCRIPTION
Fixes fetching for case-sensitive filenames like Mi8937_4_19.json https://github.com/AxionAOSP/official_devices/blob/main/OTA/VANILLA/Mi8937_4_19.json

before:
https://imgur.com/a/sl4gi8m

after:
https://imgur.com/a/pPavtlR

Change-Id: Ib8bc4e038fe0a8eb51260f5252273ed09a547d7c